### PR TITLE
Remov img-Tag by the base64 Map-image

### DIFF
--- a/lib/vacuum.js
+++ b/lib/vacuum.js
@@ -389,7 +389,8 @@ class VacuumManager {
 					}
 
 					const dataurl = data[0].toDataURL();
-					const testmap = '<img src="' + dataurl + '" style="width: auto ;height: 100%;" />';
+					const testmap = dataurl;
+					//const testmap = '<img src="' + dataurl + '" style="width: auto ;height: 100%;" />';
 					//adapter.log.info(testmap)
 					//await adapter.setStateAsync('map.map64', testmap, true);
 					await adapter.setForeignStateAsync(adapter.namespace + '.cleanmap.map64', {


### PR DESCRIPTION
It is easier to only safe the base65 image. So you can use it in several views (eg. jarvis) and you can resize the image, if it is too big with the style-settings in the img-Tag.