### PR TITLE
require node 16 due to adapter-core 3.x.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,6 +42,9 @@
   "optionalDependencies": {
     "canvas": "^2.11.2"
   },
+  "engines": {
+    "node": ">=16"
+  },
   "dependencies": {
     "@iobroker/adapter-core": "^3.0.3",
     "zlib": "^1.0.5",


### PR DESCRIPTION
adapter-core 3.x.x. fails to install using node 14 (and lower) as peerDependencies are not instaölled.
So require node 16 or higher for this adapter.

Please increase at least the minor version number at next release (good praxis if node requirments change)