### PR TITLE
Fix: apply room settings before queued cleans and avoid permanent multi-pass lockout

### DIFF
--- a/src/lib/vacuum.ts
+++ b/src/lib/vacuum.ts
@@ -1317,18 +1317,25 @@ class VacuumManager {
                         let answer = await this.Miio.sendMessage('app_segment_clean', params);
                         if (answer.error) {
                             // {"error":{"code":-10000,"message":"data for segment is not a number"}}
-                            if (params[0].repeat) {
-                                // some devices doesent support complex Object for app_segment_clean, so we have to use fallback mode
+                            if (params[0] && params[0].repeat) {
+                                // some devices don't support complex Object for app_segment_clean, so we have to use fallback mode
                                 repeat = params[0].repeat;
                                 answer = await this.Miio.sendMessage('app_segment_clean', params[0].segments);
-                                await this.adapter.setUnsupportedFeature('segemntCleanRepeat'); // we will store this for future
+                                // Remember only in-memory for this adapter run. Persisting permanently caused
+                                // native multi-pass to stay disabled after a single transient error.
+                                if (
+                                    typeof this.adapter.unsupportedFeatures === 'string' &&
+                                    this.adapter.unsupportedFeatures.indexOf('|segemntCleanRepeat|') === -1
+                                ) {
+                                    this.adapter.unsupportedFeatures += 'segemntCleanRepeat|';
+                                }
                                 this.adapter.log.info(
-                                    'repeat will not supported native, so we use Queue as Fallback in future!',
+                                    'native segment repeat not accepted by device, using queue fallback for this run',
                                 );
                             }
                         }
                         if (repeat) {
-                            // Falback mode
+                            // Fallback mode: each additional pass is a new clean job → room params must be re-applied
                             obj.info = 'repeat segment';
                             for (let i = 1; i < repeat; i++) {
                                 this.push(JSON.parse(JSON.stringify(obj)));
@@ -1601,66 +1608,99 @@ class VacuumManager {
         }
         this.cleanActiveState = cleanStatus;
         this.activeChannels = messageObj.channels;
-        if (this.activeChannels && this.activeChannels.length === 1) {
-            if (!messageObj.fanSpeed) {
-                this.adapter.getState(
-                    `${this.activeChannels[0]}.roomFanPower`,
-                    (err, fanPower) => fanPower && this.adapter.setStateChanged('control.fan_power', fanPower.val),
-                );
+        // For queued/multi-room jobs: always re-read and apply room settings before clean starts.
+        // Previously this used fire-and-forget setStateChanged, so the clean command often won the race
+        // and later passes kept the robot default (e.g. fan MAXIMUM) instead of roomFanPower.
+        if (this.activeChannels && this.activeChannels.length >= 1) {
+            // One miIO clean job can only use one fan/mop setting; use the first room as source.
+            const roomChannel = this.activeChannels[0];
+            if (messageObj.fanSpeed === undefined || messageObj.fanSpeed === null) {
+                const fanPower = await this.adapter.getStateAsync(`${roomChannel}.roomFanPower`);
+                if (fanPower && fanPower.val !== null && fanPower.val !== undefined) {
+                    messageObj.fanSpeed = fanPower.val;
+                }
             }
             if (this.features.water_box_mode != null && !messageObj.waterBoxMode) {
-                this.adapter.getState(`${this.activeChannels[0]}.roomWaterBoxMode`, (err, waterBoxMode) => {
-                    if (waterBoxMode) {
-                        this.adapter.log.debug(`Set water box mode from Room to ${waterBoxMode.val}`);
-                        this.adapter.setStateChanged('control.water_box_mode', waterBoxMode.val);
-                        if (waterBoxMode.val == 207 && this.features.water_box_mode == 2 && !messageObj.waterBoxLevel) {
-                            this.adapter.getState(
-                                `${this.activeChannels[0]}.roomWaterBoxLevel`,
-                                (err, waterBoxLevel) => {
-                                    if (waterBoxLevel) {
-                                        this.adapter.log.debug(`Set water box level from Room to ${waterBoxLevel.val}`);
-                                        this.adapter.setStateChanged(
-                                            'control.water_box_level',
-                                            waterBoxLevel.val,
-                                            true,
-                                        );
-                                    }
-                                },
-                            );
-                        }
-                    }
-                });
+                const waterBoxMode = await this.adapter.getStateAsync(`${roomChannel}.roomWaterBoxMode`);
+                if (waterBoxMode && waterBoxMode.val !== null && waterBoxMode.val !== undefined) {
+                    messageObj.waterBoxMode = waterBoxMode.val;
+                }
+            }
+            if (
+                this.features.water_box_mode == 2 &&
+                !messageObj.waterBoxLevel &&
+                Number(messageObj.waterBoxMode) === 207
+            ) {
+                const waterBoxLevel = await this.adapter.getStateAsync(`${roomChannel}.roomWaterBoxLevel`);
+                if (waterBoxLevel && waterBoxLevel.val !== null && waterBoxLevel.val !== undefined) {
+                    messageObj.waterBoxLevel = waterBoxLevel.val;
+                }
             }
             if (this.features.mop_mode != null && !messageObj.mopMode) {
-                this.adapter.getState(
-                    `${this.activeChannels[0]}.roomMopMode`,
-                    (err, mopMode) => mopMode && this.adapter.setStateChanged('control.mop_mode', mopMode.val),
-                );
+                const mopMode = await this.adapter.getStateAsync(`${roomChannel}.roomMopMode`);
+                if (mopMode && mopMode.val !== null && mopMode.val !== undefined) {
+                    messageObj.mopMode = mopMode.val;
+                }
             }
-            if (typeof messageObj.repeat === 'undefined') {
-                const repeatObj = await this.adapter.getStateAsync(`${this.activeChannels[0]}.repeat`);
+            if (this.activeChannels.length === 1 && typeof messageObj.repeat === 'undefined') {
+                const repeatObj = await this.adapter.getStateAsync(`${roomChannel}.repeat`);
                 if (repeatObj && Number(repeatObj.val) > 1) {
                     messageObj.repeat = repeatObj.val;
                 }
             }
         }
-        if (messageObj.fanSpeed) {
-            this.adapter.setState('control.fan_power', messageObj.fanSpeed);
-        }
-        if (this.features.water_box_mode != null) {
-            if (messageObj.waterBoxMode) {
-                this.adapter.setStateChanged('control.water_box_mode', messageObj.waterBoxMode);
-            }
-            if (messageObj.waterBoxLevel && this.features.water_box_mode == 2) {
-                this.adapter.setStateChanged('control.water_box_level', messageObj.waterBoxLevel);
-            }
-        }
-        if (messageObj.mopMode && this.features.mop_mode != null) {
-            this.adapter.setStateChanged('control.mop_mode', messageObj.mopMode);
-        }
+        await this.applyCleaningParams(messageObj);
         this.adapter.log.info(`trigger cleaning ${activeCleanState.name}${messageObj.message || ''}`);
         /// need to verify?? this.checkStartCleaning(2);
         return true;
+    }
+
+    /**
+     * Apply fan/water/mop params to the robot before starting a clean.
+     * Sends miIO commands directly so equal ioBroker values still reach the device
+     * (important after dock/home between queued rooms/repeats).
+     *
+     * @param messageObj cleaning request object
+     */
+    async applyCleaningParams(messageObj) {
+        if (messageObj.fanSpeed !== undefined && messageObj.fanSpeed !== null && messageObj.fanSpeed !== '') {
+            this.adapter.log.debug(`Apply fan_power ${messageObj.fanSpeed} before cleaning`);
+            await this.Miio.sendMessage('set_custom_mode', [messageObj.fanSpeed]);
+            await this.adapter.setStateAsync('control.fan_power', messageObj.fanSpeed, true);
+        }
+        if (this.features.water_box_mode != null) {
+            if (
+                messageObj.waterBoxMode !== undefined &&
+                messageObj.waterBoxMode !== null &&
+                messageObj.waterBoxMode !== ''
+            ) {
+                this.adapter.log.debug(`Apply water_box_mode ${messageObj.waterBoxMode} before cleaning`);
+                await this.Miio.sendMessage('set_water_box_custom_mode', [messageObj.waterBoxMode]);
+                await this.adapter.setStateAsync('control.water_box_mode', messageObj.waterBoxMode, true);
+            }
+            if (
+                messageObj.waterBoxLevel !== undefined &&
+                messageObj.waterBoxLevel !== null &&
+                messageObj.waterBoxLevel !== '' &&
+                this.features.water_box_mode == 2
+            ) {
+                this.adapter.log.debug(`Apply water_box_level ${messageObj.waterBoxLevel} before cleaning`);
+                await this.Miio.sendMessage('set_water_box_distance_off', {
+                    distance_off: 210 - messageObj.waterBoxLevel * 5,
+                });
+                await this.adapter.setStateAsync('control.water_box_level', messageObj.waterBoxLevel, true);
+            }
+        }
+        if (
+            messageObj.mopMode !== undefined &&
+            messageObj.mopMode !== null &&
+            messageObj.mopMode !== '' &&
+            this.features.mop_mode != null
+        ) {
+            this.adapter.log.debug(`Apply mop_mode ${messageObj.mopMode} before cleaning`);
+            await this.Miio.sendMessage('set_mop_mode', [messageObj.mopMode]);
+            await this.adapter.setStateAsync('control.mop_mode', messageObj.mopMode, true);
+        }
     }
 
     async stopCleaning() {

--- a/test/testVacuumManager.js
+++ b/test/testVacuumManager.js
@@ -44,6 +44,7 @@ function createManager(sendMessage = async () => ({})) {
         setTimeout: (callback, delay) => setTimeout(callback, delay),
         clearTimeout: timeout => clearTimeout(timeout),
         getState: (id, callback) => callback(null, null),
+        getStateAsync: async () => null,
         setStateAsync: async id => stateUpdates.push(id),
         setState: () => undefined,
         setStateChanged: () => undefined,
@@ -328,6 +329,77 @@ describe('VacuumManager object lookup', () => {
             'control.fan_power',
             'mihome-vacuum.test.rooms.living.roomFanPower',
         ]);
+        await manager.close();
+    });
+});
+
+describe('VacuumManager startCleaning room params', () => {
+    it('awaits room settings and applies them via miIO before cleaning starts', async () => {
+        const sent = [];
+        const { manager, adapter, stateUpdates } = createManager(async (method, params) => {
+            sent.push({ method, params });
+            return { result: ['ok'] };
+        });
+        adapter.getStateAsync = async id => {
+            if (id.endsWith('roomFanPower')) {
+                return { val: 102 };
+            }
+            if (id.endsWith('roomWaterBoxMode')) {
+                return { val: 201 };
+            }
+            if (id.endsWith('roomMopMode')) {
+                return { val: 300 };
+            }
+            return null;
+        };
+        manager.features.water_box_mode = 1;
+        manager.features.mop_mode = 1;
+
+        const started = await manager.startCleaning(18, {
+            channels: ['rooms.kitchen', 'rooms.living'],
+            message: 'queued rooms',
+        });
+
+        assert.equal(started, true);
+        assert.deepEqual(sent, [
+            { method: 'set_custom_mode', params: [102] },
+            { method: 'set_water_box_custom_mode', params: [201] },
+            { method: 'set_mop_mode', params: [300] },
+        ]);
+        assert.deepEqual(stateUpdates, ['control.fan_power', 'control.water_box_mode', 'control.mop_mode']);
+        await manager.close();
+    });
+
+    it('marks native segment repeat unsupported only in memory for the current run', async () => {
+        const sent = [];
+        const { manager, adapter } = createManager(async (method, params) => {
+            sent.push({ method, params });
+            if (method === 'app_segment_clean' && params && params[0] && params[0].repeat) {
+                return { error: { code: -10000, message: 'data for segment is not a number' } };
+            }
+            return { result: ['ok'] };
+        });
+        adapter.unsupportedFeatures = '|';
+        adapter.isUnsupportedFeature = key => adapter.unsupportedFeatures.indexOf(`|${key}|`) >= 0;
+        adapter.setUnsupportedFeature = async () => {
+            throw new Error('must not persist unsupported feature for transient segment-repeat errors');
+        };
+        manager.startCleaning = async () => true;
+
+        await manager.onMessage({
+            command: 'cleanSegments',
+            message: { segments: [16], repeat: 2 },
+            segments: [16],
+            channels: null,
+            repeat: 2,
+        });
+
+        assert.equal(adapter.unsupportedFeatures, '|segemntCleanRepeat|');
+        assert.equal(sent.length >= 2, true);
+        assert.equal(sent[0].method, 'app_segment_clean');
+        assert.equal(sent[1].method, 'app_segment_clean');
+        assert.deepEqual(sent[1].params, [16]);
+        assert.equal(manager.queue.length, 1);
         await manager.close();
     });
 });


### PR DESCRIPTION
## Description

This PR ports two reliability fixes for room/queue cleaning onto the current TypeScript codebase (v6).

### 1. Apply room fan / mop / water settings before each clean job
Previously, room settings were applied with fire-and-forget `setStateChanged` calls. The clean command often won the race, so later queue jobs (multi-room or repeat fallback) kept the robot default (e.g. fan MAXIMUM) instead of the configured `roomFanPower` / water / mop values.

**Change:**
- await room state reads before starting a clean
- send the parameters directly via miIO (`set_custom_mode`, `set_water_box_custom_mode`, `set_water_box_distance_off`, `set_mop_mode`)
- then update the corresponding ioBroker states with `ack: true`

### 2. Do not permanently disable native segment multi-pass after one error
If a device rejected the native `app_segment_clean` repeat object once, the adapter persisted `segemntCleanRepeat` as unsupported forever. A single transient error then disabled native multi-pass permanently.

**Change:**
- keep the unsupported flag **in-memory for the current adapter run only**
- continue using the queue fallback for that run
- do not persist the feature lockout

## Motivation

These fixes were previously validated on the pre-6.0 JavaScript adapter (fork 5.3.1 / 5.4.x) and are now adapted to `src/lib/vacuum.ts`.

Cloud login intentionally follows upstream (QR / login-link). Password + captcha + 2FA from the fork are **not** part of this PR.

## Tests

- Added unit tests in `test/testVacuumManager.js`:
  - room settings are awaited and applied via miIO before cleaning starts
  - native segment-repeat unsupported handling stays in-memory and does not call `setUnsupportedFeature`
- Existing package/runtime tests still pass for the functional changes

## Checklist

- [x] Code follows the current TypeScript runtime structure
- [x] No password/captcha/2FA login changes
- [x] Focused unit coverage for the queue/multi-pass behavior
- [ ] Please bump version / changelog as preferred by maintainers