### PR TITLE
Fix CI package policy tests and runtime defects (#1235, Alexa/IoT option, messages, map, delays)

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,7 @@ The Connection tab contains Xiaomi Cloud authentication, device discovery, and t
 - **Enable map from Xiaomi Cloud:** enables Xiaomi Cloud map downloads. Requires an authenticated cloud session.
 - **Enable Valetudo:** uses a compatible local Valetudo map source.
 - **Send own commands:** creates the expert states `control.X_send_command` and `control.X_get_response`.
+- **Add Alexa/IoT states:** additionally creates `control.pauseResume` for voice assistants and IoT integrations. `control.clean_home` always exists.
 - **Send pause before home:** sends a pause before the return-to-dock command for models that require it.
 - **Resume paused zone cleaning with start button:** resumes an interrupted zone cleaning instead of starting a complete cleaning.
 - **Advanced diagnostic logging:** adds detailed, redacted debug information. Enable it only temporarily while troubleshooting.
@@ -355,6 +356,12 @@ requests.
 * (xXBJXx) Start directly from `build/main.js` and generate Admin/VIS bundles for npm packages instead of tracking build output in Git
 * (xXBJXx) Verify script-free package installation, generated UI assets, direct startup, and Compact Mode
 * (xXBJXx) Remove unused Chai test plugins, add VS Code metadata schema support, and annotate the optional Canvas dependency for the repository checker (#1222)
+* (xXBJXx) Allow Dependabot updates of GitHub Actions and dependency versions without failing the package policy tests (#1235)
+* (xXBJXx) Restore the "Add Alexa/IoT states" option in the Admin configuration so `control.pauseResume` is no longer deleted on every start
+* (xXBJXx) Fix the `getCleaningSummary` message, which sent a consumable reset instead of requesting the cleaning summary
+* (xXBJXx) Answer the legacy `send` message only once and no longer forward it to the device manager
+* (xXBJXx) Reject map updates with a clear error when neither the Xiaomi Cloud map nor Valetudo is enabled instead of leaving the request pending
+* (xXBJXx) Track every pending internal delay separately so all of them are cancelled on unload, and remove a duplicated `control.goTo` definition
 
 ### 6.0.0 (2026-08-26)
 

--- a/README_de.md
+++ b/README_de.md
@@ -156,6 +156,7 @@ Der Tab Verbindung enthält die Xiaomi-Cloud-Anmeldung, die Gerätesuche und die
 - **Karte aus der Xiaomi Cloud aktivieren:** aktiviert den Xiaomi-Cloud-Kartenabruf und benötigt eine gültige Cloud-Sitzung.
 - **Valetudo aktivieren:** verwendet eine kompatible lokale Valetudo-Kartenquelle.
 - **Eigene Befehle senden:** erzeugt die Experten-Datenpunkte `control.X_send_command` und `control.X_get_response`.
+- **Alexa/IoT-Datenpunkte anlegen:** erzeugt zusätzlich `control.pauseResume` für Sprachassistenten und IoT-Anbindungen. `control.clean_home` ist immer vorhanden.
 - **Pause senden vor Zuhause:** sendet bei Modellen, die dies benötigen, zuerst Pause und danach den Befehl zur Ladestation.
 - **Pausierte Zonenreinigung mit Start fortsetzen:** setzt eine unterbrochene Zonenreinigung fort, statt eine vollständige Reinigung zu starten.
 - **Erweiterte Diagnoseprotokollierung:** ergänzt ausführliche, bereinigte Debug-Ausgaben. Diese Option nur vorübergehend zur Fehlersuche aktivieren.

--- a/admin/i18n/de.json
+++ b/admin/i18n/de.json
@@ -388,5 +388,6 @@
     "water filter reset": "Wasser Filter zurücksetzen",
     "waterFilter": "Wasserfilter",
     "waterFilterOid": "Lebensdauer des Wasserfilters",
-    "waterFilterResetOid": "Wasserfilter zurücksetzen"
+    "waterFilterResetOid": "Wasserfilter zurücksetzen",
+    "Add Alexa/IoT states": "Alexa/IoT-Datenpunkte anlegen"
 }

--- a/admin/i18n/en.json
+++ b/admin/i18n/en.json
@@ -388,5 +388,6 @@
     "water filter reset": "water filter reset",
     "waterFilter": "Water filter",
     "waterFilterOid": "Water filter lifetime",
-    "waterFilterResetOid": "Reset water filter"
+    "waterFilterResetOid": "Reset water filter",
+    "Add Alexa/IoT states": "Add Alexa/IoT states"
 }

--- a/admin/i18n/es.json
+++ b/admin/i18n/es.json
@@ -388,5 +388,6 @@
     "water filter reset": "restablecimiento del filtro de agua",
     "waterFilter": "Water filter",
     "waterFilterOid": "Water filter lifetime",
-    "waterFilterResetOid": "Reset water filter"
+    "waterFilterResetOid": "Reset water filter",
+    "Add Alexa/IoT states": "Añadir estados para Alexa/IoT"
 }

--- a/admin/i18n/fr.json
+++ b/admin/i18n/fr.json
@@ -388,5 +388,6 @@
     "water filter reset": "réinitialisation du filtre à eau",
     "waterFilter": "Water filter",
     "waterFilterOid": "Water filter lifetime",
-    "waterFilterResetOid": "Reset water filter"
+    "waterFilterResetOid": "Reset water filter",
+    "Add Alexa/IoT states": "Ajouter des états Alexa/IoT"
 }

--- a/admin/i18n/it.json
+++ b/admin/i18n/it.json
@@ -388,5 +388,6 @@
     "water filter reset": "reset del filtro dell'acqua",
     "waterFilter": "Water filter",
     "waterFilterOid": "Water filter lifetime",
-    "waterFilterResetOid": "Reset water filter"
+    "waterFilterResetOid": "Reset water filter",
+    "Add Alexa/IoT states": "Aggiungi stati Alexa/IoT"
 }

--- a/admin/i18n/nl.json
+++ b/admin/i18n/nl.json
@@ -388,5 +388,6 @@
     "water filter reset": "waterfilter reset",
     "waterFilter": "Water filter",
     "waterFilterOid": "Water filter lifetime",
-    "waterFilterResetOid": "Reset water filter"
+    "waterFilterResetOid": "Reset water filter",
+    "Add Alexa/IoT states": "Alexa/IoT-datapunten toevoegen"
 }

--- a/admin/i18n/pl.json
+++ b/admin/i18n/pl.json
@@ -388,5 +388,6 @@
     "water filter reset": "reset filtra wody",
     "waterFilter": "Water filter",
     "waterFilterOid": "Water filter lifetime",
-    "waterFilterResetOid": "Reset water filter"
+    "waterFilterResetOid": "Reset water filter",
+    "Add Alexa/IoT states": "Dodaj stany Alexa/IoT"
 }

--- a/admin/i18n/pt.json
+++ b/admin/i18n/pt.json
@@ -388,5 +388,6 @@
     "water filter reset": "redefinição do filtro de água",
     "waterFilter": "Water filter",
     "waterFilterOid": "Water filter lifetime",
-    "waterFilterResetOid": "Reset water filter"
+    "waterFilterResetOid": "Reset water filter",
+    "Add Alexa/IoT states": "Adicionar estados Alexa/IoT"
 }

--- a/admin/i18n/ru.json
+++ b/admin/i18n/ru.json
@@ -388,5 +388,6 @@
     "water filter reset": "сброс фильтра воды",
     "waterFilter": "Water filter",
     "waterFilterOid": "Water filter lifetime",
-    "waterFilterResetOid": "Reset water filter"
+    "waterFilterResetOid": "Reset water filter",
+    "Add Alexa/IoT states": "Добавить состояния Alexa/IoT"
 }

--- a/admin/i18n/uk.json
+++ b/admin/i18n/uk.json
@@ -388,5 +388,6 @@
     "water filter reset": "water filter reset",
     "waterFilter": "Water filter",
     "waterFilterOid": "Water filter lifetime",
-    "waterFilterResetOid": "Reset water filter"
+    "waterFilterResetOid": "Reset water filter",
+    "Add Alexa/IoT states": "Додати стани Alexa/IoT"
 }

--- a/admin/i18n/zh-cn.json
+++ b/admin/i18n/zh-cn.json
@@ -388,5 +388,6 @@
     "water filter reset": "滤水器重置",
     "waterFilter": "Water filter",
     "waterFilterOid": "Water filter lifetime",
-    "waterFilterResetOid": "Reset water filter"
+    "waterFilterResetOid": "Reset water filter",
+    "Add Alexa/IoT states": "添加 Alexa/IoT 状态"
 }

--- a/io-package.json
+++ b/io-package.json
@@ -265,6 +265,7 @@
     "lib": "",
     "enableMiMap": false,
     "enableSelfCommands": false,
+    "enableAlexa": false,
     "enableAdvancedDebug": false,
     "sendPauseBeforeHome": false,
     "enableResumeZone": false,

--- a/main.lifecycle.test.js
+++ b/main.lifecycle.test.js
@@ -11,6 +11,8 @@ class FakeAdapter extends EventEmitter {
         this.warnMessages = [];
         this.errorMessages = [];
         this.sentMessages = [];
+        this.createdObjects = [];
+        this.deletedObjects = [];
         this.log = {
             debug: message => this.debugMessages.push(String(message)),
             info: () => undefined,
@@ -19,9 +21,13 @@ class FakeAdapter extends EventEmitter {
         };
     }
 
-    async setObjectNotExistsAsync() {}
+    async setObjectNotExistsAsync(id) {
+        this.createdObjects.push(id);
+    }
     async extendObjectAsync() {}
-    async delObjectAsync() {}
+    async delObjectAsync(id) {
+        this.deletedObjects.push(id);
+    }
     async getStateAsync() {
         return null;
     }
@@ -34,9 +40,10 @@ class FakeAdapter extends EventEmitter {
 }
 
 /**
- * @param {{ closeThrows?: boolean, managerCloseThrows?: boolean, managerReadyRejects?: boolean, managerCommandRejects?: boolean, managerStateChangeRejects?: boolean, modelResponses?: object[] }} [options]
+ * @param {{ closeThrows?: boolean, managerCloseThrows?: boolean, managerReadyRejects?: boolean, managerCommandRejects?: boolean, managerStateChangeRejects?: boolean, modelResponses?: object[], config?: object }} [options]
  */
 function createAdapter({
+    config = {},
     closeThrows = false,
     managerCloseThrows = false,
     managerReadyRejects = false,
@@ -111,6 +118,7 @@ function createAdapter({
             config: {
                 token: '00000000000000000000000000000000',
                 pingInterval: 20000,
+                ...config,
             },
         }),
         counters,
@@ -531,5 +539,35 @@ describe('Adapter unload lifecycle', () => {
         assert.equal(adapter.unsupportedFeatures, '|segemntCleanRepeat|');
         assert.equal(adapter.warnMessages.includes('Could not persist a detected unsupported device feature'), true);
         assert.equal(adapter.warnMessages.join('\n').includes('SENSITIVE_UNSUPPORTED_WRITE_MARKER'), false);
+    });
+
+    it('answers the legacy send command exactly once without forwarding it to the manager', async () => {
+        const { adapter } = createAdapter();
+
+        await adapter.main();
+        await adapter.getModel();
+        await adapter.onMessage({ command: 'send', message: { text: 'hello' }, from: 'script', callback: 'request' });
+
+        assert.deepEqual(
+            adapter.sentMessages.map(message => message.response),
+            ['Message received'],
+        );
+        await adapter.onUnload(() => undefined);
+    });
+
+    it('always creates clean_home and adds the IoT states only when enableAlexa is set', async () => {
+        const withoutAlexa = createAdapter().adapter;
+        await withoutAlexa.main();
+        assert.equal(withoutAlexa.createdObjects.includes('control.clean_home'), true);
+        assert.equal(withoutAlexa.createdObjects.includes('control.pauseResume'), false);
+        assert.equal(withoutAlexa.deletedObjects.includes('control.pauseResume'), true);
+        await withoutAlexa.onUnload(() => undefined);
+
+        const withAlexa = createAdapter({ config: { enableAlexa: true } }).adapter;
+        await withAlexa.main();
+        assert.equal(withAlexa.createdObjects.includes('control.clean_home'), true);
+        assert.equal(withAlexa.createdObjects.includes('control.pauseResume'), true);
+        assert.equal(withAlexa.deletedObjects.includes('control.pauseResume'), false);
+        await withAlexa.onUnload(() => undefined);
     });
 });

--- a/src-admin/src/App.tsx
+++ b/src-admin/src/App.tsx
@@ -100,6 +100,7 @@ const defaultNative: VacuumNative = {
     manager: '',
     enableMiMap: false,
     enableSelfCommands: false,
+    enableAlexa: false,
     enableAdvancedDebug: false,
     sendPauseBeforeHome: false,
     enableResumeZone: false,
@@ -895,6 +896,15 @@ class App extends GenericApp<GenericAppProps, VacuumAdminState> {
                                     />
                                 }
                                 label={I18n.t('Send own commands')}
+                            />
+                            <FormControlLabel
+                                control={
+                                    <Checkbox
+                                        checked={this.state.native.enableAlexa}
+                                        onChange={event => this.updateNative('enableAlexa', event.target.checked)}
+                                    />
+                                }
+                                label={I18n.t('Add Alexa/IoT states')}
                             />
                             <FormControlLabel
                                 control={

--- a/src-admin/src/types.ts
+++ b/src-admin/src/types.ts
@@ -26,6 +26,7 @@ export interface VacuumNative extends Record<string, unknown> {
     manager: string;
     enableMiMap: boolean;
     enableSelfCommands: boolean;
+    enableAlexa: boolean;
     enableAdvancedDebug: boolean;
     sendPauseBeforeHome: boolean;
     enableResumeZone: boolean;

--- a/src/lib/maphelper.ts
+++ b/src/lib/maphelper.ts
@@ -202,6 +202,12 @@ class MapHelper {
                 this.getMapBase64()
                     .then(mapData => resolve(mapData))
                     .catch(error => reject(error));
+            } else {
+                reject(
+                    new Error(
+                        'No map source enabled; enable the Xiaomi Cloud map or Valetudo in the adapter configuration',
+                    ),
+                );
             }
         });
     }

--- a/src/lib/objects.ts
+++ b/src/lib/objects.ts
@@ -909,19 +909,6 @@ const objects = {
             native: {},
         },
         {
-            _id: 'goTo',
-            type: 'state',
-            common: {
-                name: 'Go to point',
-                type: 'string',
-                def: '',
-                read: true,
-                write: true,
-                desc: 'let the vacuum go to a point on the map',
-            },
-            native: {},
-        },
-        {
             _id: 'zoneClean',
             type: 'state',
             common: {

--- a/src/lib/vacuum.ts
+++ b/src/lib/vacuum.ts
@@ -55,6 +55,7 @@ class VacuumManager {
         this.carpetModeSettings = { ...defaultCarpetModeSettings };
         this.adapter = adapterInstance;
         this.globalTimeouts = {};
+        this.delayCounter = 0;
         this.closed = false;
         this.logEntries = [];
         this.Error = false;
@@ -428,7 +429,14 @@ class VacuumManager {
     }
 
     async delay(time) {
-        return new Promise(resolve => (this.globalTimeouts['delay'] = this.adapter.setTimeout(resolve, time)));
+        // Every pending delay keeps its own handle so overlapping delays are all cancelled on close().
+        const key = `delay_${++this.delayCounter}`;
+        return new Promise<void>(resolve => {
+            this.globalTimeouts[key] = this.adapter.setTimeout(() => {
+                delete this.globalTimeouts[key];
+                resolve();
+            }, time);
+        });
     }
 
     async getMapData() {
@@ -1375,7 +1383,7 @@ class VacuumManager {
 
                 // get info about cleanups
                 case 'getCleaningSummary':
-                    return await this.Miio.sendMessage('reset_consumable', obj.message.consumable);
+                    return await this.Miio.sendMessage('get_clean_summary');
 
                 case 'getCleaningRecord':
                     // require the record id to be given

--- a/src/main.ts
+++ b/src/main.ts
@@ -637,23 +637,16 @@ export class MihomeVacuum extends utils.Adapter {
      * @param obj message object
      */
     async onMessage(obj) {
-        if (typeof obj === 'object' && obj.message) {
-            if (obj.command === 'send') {
-                // e.g. send email or pushover or whatever
-                this.log.info('send command');
-
-                // Send response in callback if required
-                if (obj.callback) {
-                    this.sendTo(obj.from, obj.command, 'Message received', obj.callback);
-                }
-            }
-        }
         // responds to the adapter that sent the original message
         const respond = response => obj.callback && this.sendTo(obj.from, obj.command, response, obj.callback);
 
         // handle the message
         if (obj) {
             switch (obj.command) {
+                case 'send':
+                    // Legacy template command: answer exactly once and never forward it to the manager.
+                    this.log.info('send command');
+                    return respond('Message received');
                 case 'discovery': {
                     if (!this.xiaomiApi) {
                         this.xiaomiApi = new XiaomiCloudConnector(this.log, obj.message.authObj, this);

--- a/test/package.js
+++ b/test/package.js
@@ -11,7 +11,7 @@ describe('Runtime dependencies', () => {
     it('keeps Canvas optional so local control does not require native graphics libraries', () => {
         const packageJson = require('../package.json');
 
-        assert.equal(packageJson.optionalDependencies.canvas, '^3.2.3');
+        assert.match(packageJson.optionalDependencies.canvas, /^\^[3-9]\.\d+\.\d+$/);
         assert.equal(Object.hasOwn(packageJson.dependencies, 'canvas'), false);
         const renderer = fs.readFileSync(path.join(__dirname, '..', 'src', 'lib', 'mapCreator.ts'), 'utf8');
         assert.match(renderer, /^\/\/ @repochecker: optional dependency 'canvas'$/m);
@@ -80,23 +80,28 @@ describe('Runtime dependencies', () => {
     it('declares axios as a production dependency', () => {
         const packageJson = require('../package.json');
 
-        assert.equal(packageJson.dependencies.axios, '^1.20.0');
+        assert.match(packageJson.dependencies.axios, /^\^[1-9]\d*\.\d+\.\d+$/);
         assert.equal(Object.prototype.hasOwnProperty.call(packageJson.devDependencies, 'axios'), false);
-        assert.equal(packageJson.dependencies.qs, '^6.15.3');
+        assert.match(packageJson.dependencies.qs, /^\^[6-9]\.\d+\.\d+$/);
     });
 
-    it('keeps the approved ioBroker and release toolchain on the current baseline', () => {
+    it('keeps the approved ioBroker and release toolchain declared with caret ranges', () => {
         const packageJson = require('../package.json');
+        const caretRange = /^\^\d+\.\d+\.\d+$/;
 
-        assert.equal(packageJson.dependencies['@iobroker/adapter-core'], '^3.4.3');
-        assert.equal(packageJson.devDependencies['@iobroker/testing'], '^5.3.0');
-        assert.equal(packageJson.devDependencies['@iobroker/adapter-dev'], '^1.5.0');
-        assert.equal(packageJson.devDependencies['@iobroker/eslint-config'], '^2.3.4');
-        assert.equal(packageJson.devDependencies['@tsconfig/node22'], '^22.0.6');
-        assert.equal(packageJson.devDependencies['@alcalzone/release-script'], '^5.2.1');
-        assert.equal(packageJson.devDependencies['@alcalzone/release-script-plugin-iobroker'], '^5.2.0');
-        assert.equal(packageJson.devDependencies['@alcalzone/release-script-plugin-license'], '^5.2.2');
-        assert.equal(packageJson.devDependencies['@alcalzone/release-script-plugin-manual-review'], '^5.2.0');
+        assert.match(packageJson.dependencies['@iobroker/adapter-core'], /^\^[3-9]\.\d+\.\d+$/);
+        for (const dependency of [
+            '@iobroker/testing',
+            '@iobroker/adapter-dev',
+            '@iobroker/eslint-config',
+            '@tsconfig/node22',
+            '@alcalzone/release-script',
+            '@alcalzone/release-script-plugin-iobroker',
+            '@alcalzone/release-script-plugin-license',
+            '@alcalzone/release-script-plugin-manual-review',
+        ]) {
+            assert.match(packageJson.devDependencies[dependency] ?? '', caretRange, dependency);
+        }
     });
 
     it('declares the documented Node.js, js-controller, and Admin minimum versions', () => {
@@ -106,7 +111,7 @@ describe('Runtime dependencies', () => {
         assert.equal(packageJson.engines.node, '>=22.13.0');
         assert.equal(ioPackage.common.dependencies[0]['js-controller'], '>=7.2.2');
         assert.equal(ioPackage.common.globalDependencies[0].admin, '>=7.8.23');
-        assert.equal(packageJson.devDependencies['@types/node'], '^22.20.0');
+        assert.match(packageJson.devDependencies['@types/node'], /^\^(?:2[2-9]|[3-9]\d)\.\d+\.\d+$/);
     });
 
     it('declares only instance objects with non-empty IDs', () => {
@@ -388,15 +393,17 @@ describe('Runtime dependencies', () => {
             'utf8',
         );
 
+        // Node.js 22 is the primary baseline; the matrix may add newer versions.
         assert.match(workflow, /node-version: "22\.x"/);
-        assert.match(workflow, /node-version: \[22\.x, 24\.x\]/);
+        assert.match(workflow, /node-version: \[22\.x(?:, (?:2[4-9]|[3-9]\d)\.x)*\]/);
         assert.doesNotMatch(workflow, /node-version: (?:18|20)\.x/);
         assert.doesNotMatch(workflow, /node-version: \[[^\]]*(?:18|20)\.x/);
-        assert.equal([...workflow.matchAll(/actions\/checkout@v7/g)].length, 1);
-        assert.equal([...workflow.matchAll(/actions\/setup-node@v7/g)].length, 1);
-        assert.doesNotMatch(workflow, /actions\/(?:checkout|setup-node)@v[1-6]/);
-        assert.match(workflow, /uses: ioBroker\/testing-action-check@v1/);
-        assert.match(workflow, /uses: ioBroker\/testing-action-adapter@v1/);
+        // Official actions are used exactly once each; Dependabot may raise their major versions.
+        assert.equal([...workflow.matchAll(/actions\/checkout@v\d+/g)].length, 1);
+        assert.equal([...workflow.matchAll(/actions\/setup-node@v\d+/g)].length, 1);
+        assert.doesNotMatch(workflow, /actions\/(?:checkout|setup-node)@v[1-6]/);
+        assert.match(workflow, /uses: ioBroker\/testing-action-check@v\d+/);
+        assert.match(workflow, /uses: ioBroker\/testing-action-adapter@v\d+/);
         assert.match(workflow, /group: \$\{\{ github\.ref \}\}/);
         assert.match(workflow, /cancel-in-progress: true/);
         assert.match(workflow, /- name: Type-check source code\s+run: npm run check/);
@@ -413,8 +420,8 @@ describe('Runtime dependencies', () => {
         assert.match(deployJob, /needs: \[regression-tests, check-and-lint, adapter-tests\]/);
         assert.match(deployJob, /contents: write/);
         assert.match(deployJob, /id-token: write/);
-        assert.match(deployJob, /uses: ioBroker\/testing-action-deploy@v1/);
-        assert.match(deployJob, /node-version: "24\.x"/);
+        assert.match(deployJob, /uses: ioBroker\/testing-action-deploy@v\d+/);
+        assert.match(deployJob, /node-version: "(?:2[4-9]|[3-9]\d)\.x"/);
         assert.match(deployJob, /package-cache: "false"/);
         assert.match(deployJob, /^                  build: true$/m);
         assert.match(deployJob, /^                  build-command: "npm run build"$/m);

--- a/test/testMaphelper.js
+++ b/test/testMaphelper.js
@@ -51,6 +51,18 @@ describe('MapHelper logging', () => {
         assert.equal(debugMessages.some(message => message.includes(sensitiveLocationMarker)), false);
     });
 
+    it('rejects a map update when neither the cloud map nor Valetudo is enabled', async () => {
+        const mapHelper = new MapHelper({}, createAdapter());
+        mapHelper.getMapURL = async () => {
+            throw new Error('must not be called');
+        };
+        mapHelper.getMapBase64 = async () => {
+            throw new Error('must not be called');
+        };
+
+        await assert.rejects(mapHelper.updateMap('map-without-source'), /No map source enabled/);
+    });
+
     it('shuts down its cloud connector once', async () => {
         const adapter = {
             config: {},

--- a/test/testObjectsMigration.js
+++ b/test/testObjectsMigration.js
@@ -6,7 +6,7 @@ describe('ioBroker object TypeScript runtime catalog', () => {
     it('matches the reviewed complete recursive catalog fixture', () => {
         const digest = crypto.createHash('sha256').update(JSON.stringify(objects)).digest('hex');
 
-        assert.equal(digest, '50d814aecdd313ea2fce1068139311fc1ac5d96d8a28da7f2f12fe2a74137fec');
+        assert.equal(digest, '3c7a3e539f9affaf9432ce9bbd5a1ea2778301c34fab3a14ee9e65aa14d784d3');
     });
 
     it('preserves every top-level catalog consumed by runtime managers', () => {

--- a/test/testVacuumManager.js
+++ b/test/testVacuumManager.js
@@ -330,4 +330,46 @@ describe('VacuumManager object lookup', () => {
         ]);
         await manager.close();
     });
+
+    it('requests the cleaning summary for the getCleaningSummary message', async () => {
+        const calls = [];
+        const { manager } = createManager(async (method, params) => {
+            calls.push({ method, params });
+            return { result: [1, 2, 3] };
+        });
+
+        const response = await manager.onMessage({ command: 'getCleaningSummary', message: {} });
+
+        assert.deepEqual(calls, [{ method: 'get_clean_summary', params: undefined }]);
+        assert.deepEqual(response, { result: [1, 2, 3] });
+        await manager.close();
+    });
+
+    it('keeps a separate handle for every pending delay and cancels all of them on close', async () => {
+        const clock = sinon.useFakeTimers();
+        try {
+            const { manager } = createManager();
+            let settled = 0;
+
+            const first = manager.delay(1_000).then(() => settled++);
+            const second = manager.delay(1_000).then(() => settled++);
+            const pendingKeys = Object.keys(manager.globalTimeouts).filter(key => key.startsWith('delay_'));
+            assert.equal(pendingKeys.length, 2);
+
+            await clock.tickAsync(1_000);
+            await Promise.all([first, second]);
+            assert.equal(settled, 2);
+            assert.deepEqual(
+                Object.keys(manager.globalTimeouts).filter(key => manager.globalTimeouts[key]),
+                [],
+            );
+
+            void manager.delay(5_000);
+            await manager.close();
+            await clock.tickAsync(5_000);
+            assert.equal(settled, 2);
+        } finally {
+            clock.restore();
+        }
+    });
 });


### PR DESCRIPTION
## Summary

Two focused commits on top of the current `master` (`895fc16`).

### 1. Package policy tests no longer break on Dependabot updates (#1235, #1226 E3031)

`test/package.js` asserted exact dependency version strings and exact major versions of the GitHub Actions in `test-and-release.yml`. Dependabot bumped `ioBroker/testing-action-check` to `v2` (#1215), which turned the CI on `master` red.

- Dependencies are now checked for caret ranges with a minimum major instead of exact versions.
- Official ioBroker and GitHub actions may use any current major; retired majors (`checkout`/`setup-node` v1-v6) stay rejected.
- Node.js 22.x remains the required primary CI version; the matrix may add newer versions.

### 2. Runtime defects

- **Restore the "Add Alexa/IoT states" option** (`enableAlexa`) in `io-package.json` and the React admin. It was lost in the 6.0.0 migration, so `control.pauseResume` was deleted on every adapter start although the manager handles it. `control.clean_home` is unaffected and always created. Translation key added to all 11 `admin/i18n` files, README/README_de updated.
- **Legacy `send` message** answered once and no longer forwarded to the device manager (previously responded twice on the same callback).
- **`getCleaningSummary` message** now sends `get_clean_summary` instead of `reset_consumable`.
- **`MapHelper.updateMap`** rejects with a clear error when neither the cloud map nor Valetudo is enabled instead of leaving the promise pending forever.
- **`VacuumManager.delay`** keeps a separate timeout handle per pending delay so `close()` cancels all of them.
- **Duplicated `control.goTo` definition** removed from the object catalog; reviewed catalog digest updated in `test/testObjectsMigration.js` (identical definitions, no runtime change).

## Tests

- `npm run lint` passes
- `npm run check` passes
- `npm run test:js`: 214 passing (5 new regression tests: single `send` response, `enableAlexa` object creation/deletion, `getCleaningSummary` payload, per-delay handles cancelled on close, `updateMap` rejection without map source)
- `npm run test:package`: 81 passing
- `npm run test:package-smoke`: passed (95 files, clean runtime install)

## Notes for reviewers

- No version bump and no release in this PR. A release is still needed for #1223 and can follow once this is merged.
- No changes to the Xiaomi Cloud boundary.
- Viomi `water_grade` sending `set_suction` was reviewed and is intentionally unchanged; it matches the Viomi firmware contract (values 11-13, same as python-miio).
- Changelog entries were added under `### **WORK IN PROGRESS**` in `README.md`.

Closes #1235
