### PR TITLE
Apply room settings before queued cleans and keep multi-pass lockout in memory (#1231)

### DIFF
--- a/README.md
+++ b/README.md
@@ -362,6 +362,9 @@ requests.
 * (xXBJXx) Answer the legacy `send` message only once and no longer forward it to the device manager
 * (xXBJXx) Reject map updates with a clear error when neither the Xiaomi Cloud map nor Valetudo is enabled instead of leaving the request pending
 * (xXBJXx) Track every pending internal delay separately so all of them are cancelled on unload, and remove a duplicated `control.goTo` definition
+* (kosmix1980) Apply the room fan, water and mop settings through miIO before queued and repeated room cleanings start instead of racing them against the start command (#1231)
+* (kosmix1980) Keep the native multi-pass segment cleaning lockout only for the current run instead of persisting it after a single error (#1231)
+* (xXBJXx) Continue starting the cleaning with a warning when a fan, water or mop parameter command fails
 
 ### 6.0.0 (2026-08-26)
 

--- a/src/lib/vacuum.ts
+++ b/src/lib/vacuum.ts
@@ -1657,7 +1657,14 @@ class VacuumManager {
                 }
             }
         }
-        await this.applyCleaningParams(messageObj);
+        try {
+            await this.applyCleaningParams(messageObj);
+        } catch (error) {
+            // A failed fan/water/mop command must not prevent the cleaning itself from starting.
+            this.adapter.log.warn(
+                `Could not apply cleaning parameters before start: ${error instanceof Error ? error.message : String(error)}`,
+            );
+        }
         this.adapter.log.info(`trigger cleaning ${activeCleanState.name}${messageObj.message || ''}`);
         /// need to verify?? this.checkStartCleaning(2);
         return true;

--- a/src/lib/vacuum.ts
+++ b/src/lib/vacuum.ts
@@ -1325,18 +1325,25 @@ class VacuumManager {
                         let answer = await this.Miio.sendMessage('app_segment_clean', params);
                         if (answer.error) {
                             // {"error":{"code":-10000,"message":"data for segment is not a number"}}
-                            if (params[0].repeat) {
-                                // some devices doesent support complex Object for app_segment_clean, so we have to use fallback mode
+                            if (params[0] && params[0].repeat) {
+                                // some devices don't support complex Object for app_segment_clean, so we have to use fallback mode
                                 repeat = params[0].repeat;
                                 answer = await this.Miio.sendMessage('app_segment_clean', params[0].segments);
-                                await this.adapter.setUnsupportedFeature('segemntCleanRepeat'); // we will store this for future
+                                // Remember only in-memory for this adapter run. Persisting permanently caused
+                                // native multi-pass to stay disabled after a single transient error.
+                                if (
+                                    typeof this.adapter.unsupportedFeatures === 'string' &&
+                                    this.adapter.unsupportedFeatures.indexOf('|segemntCleanRepeat|') === -1
+                                ) {
+                                    this.adapter.unsupportedFeatures += 'segemntCleanRepeat|';
+                                }
                                 this.adapter.log.info(
-                                    'repeat will not supported native, so we use Queue as Fallback in future!',
+                                    'native segment repeat not accepted by device, using queue fallback for this run',
                                 );
                             }
                         }
                         if (repeat) {
-                            // Falback mode
+                            // Fallback mode: each additional pass is a new clean job → room params must be re-applied
                             obj.info = 'repeat segment';
                             for (let i = 1; i < repeat; i++) {
                                 this.push(JSON.parse(JSON.stringify(obj)));
@@ -1609,66 +1616,99 @@ class VacuumManager {
         }
         this.cleanActiveState = cleanStatus;
         this.activeChannels = messageObj.channels;
-        if (this.activeChannels && this.activeChannels.length === 1) {
-            if (!messageObj.fanSpeed) {
-                this.adapter.getState(
-                    `${this.activeChannels[0]}.roomFanPower`,
-                    (err, fanPower) => fanPower && this.adapter.setStateChanged('control.fan_power', fanPower.val),
-                );
+        // For queued/multi-room jobs: always re-read and apply room settings before clean starts.
+        // Previously this used fire-and-forget setStateChanged, so the clean command often won the race
+        // and later passes kept the robot default (e.g. fan MAXIMUM) instead of roomFanPower.
+        if (this.activeChannels && this.activeChannels.length >= 1) {
+            // One miIO clean job can only use one fan/mop setting; use the first room as source.
+            const roomChannel = this.activeChannels[0];
+            if (messageObj.fanSpeed === undefined || messageObj.fanSpeed === null) {
+                const fanPower = await this.adapter.getStateAsync(`${roomChannel}.roomFanPower`);
+                if (fanPower && fanPower.val !== null && fanPower.val !== undefined) {
+                    messageObj.fanSpeed = fanPower.val;
+                }
             }
             if (this.features.water_box_mode != null && !messageObj.waterBoxMode) {
-                this.adapter.getState(`${this.activeChannels[0]}.roomWaterBoxMode`, (err, waterBoxMode) => {
-                    if (waterBoxMode) {
-                        this.adapter.log.debug(`Set water box mode from Room to ${waterBoxMode.val}`);
-                        this.adapter.setStateChanged('control.water_box_mode', waterBoxMode.val);
-                        if (waterBoxMode.val == 207 && this.features.water_box_mode == 2 && !messageObj.waterBoxLevel) {
-                            this.adapter.getState(
-                                `${this.activeChannels[0]}.roomWaterBoxLevel`,
-                                (err, waterBoxLevel) => {
-                                    if (waterBoxLevel) {
-                                        this.adapter.log.debug(`Set water box level from Room to ${waterBoxLevel.val}`);
-                                        this.adapter.setStateChanged(
-                                            'control.water_box_level',
-                                            waterBoxLevel.val,
-                                            true,
-                                        );
-                                    }
-                                },
-                            );
-                        }
-                    }
-                });
+                const waterBoxMode = await this.adapter.getStateAsync(`${roomChannel}.roomWaterBoxMode`);
+                if (waterBoxMode && waterBoxMode.val !== null && waterBoxMode.val !== undefined) {
+                    messageObj.waterBoxMode = waterBoxMode.val;
+                }
+            }
+            if (
+                this.features.water_box_mode == 2 &&
+                !messageObj.waterBoxLevel &&
+                Number(messageObj.waterBoxMode) === 207
+            ) {
+                const waterBoxLevel = await this.adapter.getStateAsync(`${roomChannel}.roomWaterBoxLevel`);
+                if (waterBoxLevel && waterBoxLevel.val !== null && waterBoxLevel.val !== undefined) {
+                    messageObj.waterBoxLevel = waterBoxLevel.val;
+                }
             }
             if (this.features.mop_mode != null && !messageObj.mopMode) {
-                this.adapter.getState(
-                    `${this.activeChannels[0]}.roomMopMode`,
-                    (err, mopMode) => mopMode && this.adapter.setStateChanged('control.mop_mode', mopMode.val),
-                );
+                const mopMode = await this.adapter.getStateAsync(`${roomChannel}.roomMopMode`);
+                if (mopMode && mopMode.val !== null && mopMode.val !== undefined) {
+                    messageObj.mopMode = mopMode.val;
+                }
             }
-            if (typeof messageObj.repeat === 'undefined') {
-                const repeatObj = await this.adapter.getStateAsync(`${this.activeChannels[0]}.repeat`);
+            if (this.activeChannels.length === 1 && typeof messageObj.repeat === 'undefined') {
+                const repeatObj = await this.adapter.getStateAsync(`${roomChannel}.repeat`);
                 if (repeatObj && Number(repeatObj.val) > 1) {
                     messageObj.repeat = repeatObj.val;
                 }
             }
         }
-        if (messageObj.fanSpeed) {
-            this.adapter.setState('control.fan_power', messageObj.fanSpeed);
-        }
-        if (this.features.water_box_mode != null) {
-            if (messageObj.waterBoxMode) {
-                this.adapter.setStateChanged('control.water_box_mode', messageObj.waterBoxMode);
-            }
-            if (messageObj.waterBoxLevel && this.features.water_box_mode == 2) {
-                this.adapter.setStateChanged('control.water_box_level', messageObj.waterBoxLevel);
-            }
-        }
-        if (messageObj.mopMode && this.features.mop_mode != null) {
-            this.adapter.setStateChanged('control.mop_mode', messageObj.mopMode);
-        }
+        await this.applyCleaningParams(messageObj);
         this.adapter.log.info(`trigger cleaning ${activeCleanState.name}${messageObj.message || ''}`);
         /// need to verify?? this.checkStartCleaning(2);
         return true;
+    }
+
+    /**
+     * Apply fan/water/mop params to the robot before starting a clean.
+     * Sends miIO commands directly so equal ioBroker values still reach the device
+     * (important after dock/home between queued rooms/repeats).
+     *
+     * @param messageObj cleaning request object
+     */
+    async applyCleaningParams(messageObj) {
+        if (messageObj.fanSpeed !== undefined && messageObj.fanSpeed !== null && messageObj.fanSpeed !== '') {
+            this.adapter.log.debug(`Apply fan_power ${messageObj.fanSpeed} before cleaning`);
+            await this.Miio.sendMessage('set_custom_mode', [messageObj.fanSpeed]);
+            await this.adapter.setStateAsync('control.fan_power', messageObj.fanSpeed, true);
+        }
+        if (this.features.water_box_mode != null) {
+            if (
+                messageObj.waterBoxMode !== undefined &&
+                messageObj.waterBoxMode !== null &&
+                messageObj.waterBoxMode !== ''
+            ) {
+                this.adapter.log.debug(`Apply water_box_mode ${messageObj.waterBoxMode} before cleaning`);
+                await this.Miio.sendMessage('set_water_box_custom_mode', [messageObj.waterBoxMode]);
+                await this.adapter.setStateAsync('control.water_box_mode', messageObj.waterBoxMode, true);
+            }
+            if (
+                messageObj.waterBoxLevel !== undefined &&
+                messageObj.waterBoxLevel !== null &&
+                messageObj.waterBoxLevel !== '' &&
+                this.features.water_box_mode == 2
+            ) {
+                this.adapter.log.debug(`Apply water_box_level ${messageObj.waterBoxLevel} before cleaning`);
+                await this.Miio.sendMessage('set_water_box_distance_off', {
+                    distance_off: 210 - messageObj.waterBoxLevel * 5,
+                });
+                await this.adapter.setStateAsync('control.water_box_level', messageObj.waterBoxLevel, true);
+            }
+        }
+        if (
+            messageObj.mopMode !== undefined &&
+            messageObj.mopMode !== null &&
+            messageObj.mopMode !== '' &&
+            this.features.mop_mode != null
+        ) {
+            this.adapter.log.debug(`Apply mop_mode ${messageObj.mopMode} before cleaning`);
+            await this.Miio.sendMessage('set_mop_mode', [messageObj.mopMode]);
+            await this.adapter.setStateAsync('control.mop_mode', messageObj.mopMode, true);
+        }
     }
 
     async stopCleaning() {

--- a/test/testVacuumManager.js
+++ b/test/testVacuumManager.js
@@ -44,6 +44,7 @@ function createManager(sendMessage = async () => ({})) {
         setTimeout: (callback, delay) => setTimeout(callback, delay),
         clearTimeout: timeout => clearTimeout(timeout),
         getState: (id, callback) => callback(null, null),
+        getStateAsync: async () => null,
         setStateAsync: async id => stateUpdates.push(id),
         setState: () => undefined,
         setStateChanged: () => undefined,
@@ -371,5 +372,76 @@ describe('VacuumManager object lookup', () => {
         } finally {
             clock.restore();
         }
+    });
+});
+
+describe('VacuumManager startCleaning room params', () => {
+    it('awaits room settings and applies them via miIO before cleaning starts', async () => {
+        const sent = [];
+        const { manager, adapter, stateUpdates } = createManager(async (method, params) => {
+            sent.push({ method, params });
+            return { result: ['ok'] };
+        });
+        adapter.getStateAsync = async id => {
+            if (id.endsWith('roomFanPower')) {
+                return { val: 102 };
+            }
+            if (id.endsWith('roomWaterBoxMode')) {
+                return { val: 201 };
+            }
+            if (id.endsWith('roomMopMode')) {
+                return { val: 300 };
+            }
+            return null;
+        };
+        manager.features.water_box_mode = 1;
+        manager.features.mop_mode = 1;
+
+        const started = await manager.startCleaning(18, {
+            channels: ['rooms.kitchen', 'rooms.living'],
+            message: 'queued rooms',
+        });
+
+        assert.equal(started, true);
+        assert.deepEqual(sent, [
+            { method: 'set_custom_mode', params: [102] },
+            { method: 'set_water_box_custom_mode', params: [201] },
+            { method: 'set_mop_mode', params: [300] },
+        ]);
+        assert.deepEqual(stateUpdates, ['control.fan_power', 'control.water_box_mode', 'control.mop_mode']);
+        await manager.close();
+    });
+
+    it('marks native segment repeat unsupported only in memory for the current run', async () => {
+        const sent = [];
+        const { manager, adapter } = createManager(async (method, params) => {
+            sent.push({ method, params });
+            if (method === 'app_segment_clean' && params && params[0] && params[0].repeat) {
+                return { error: { code: -10000, message: 'data for segment is not a number' } };
+            }
+            return { result: ['ok'] };
+        });
+        adapter.unsupportedFeatures = '|';
+        adapter.isUnsupportedFeature = key => adapter.unsupportedFeatures.indexOf(`|${key}|`) >= 0;
+        adapter.setUnsupportedFeature = async () => {
+            throw new Error('must not persist unsupported feature for transient segment-repeat errors');
+        };
+        manager.startCleaning = async () => true;
+
+        await manager.onMessage({
+            command: 'cleanSegments',
+            message: { segments: [16], repeat: 2 },
+            segments: [16],
+            channels: null,
+            repeat: 2,
+        });
+
+        assert.equal(adapter.unsupportedFeatures, '|segemntCleanRepeat|');
+        assert.equal(sent.length >= 2, true);
+        assert.equal(sent[0].method, 'app_segment_clean');
+        assert.equal(sent[1].method, 'app_segment_clean');
+        assert.deepEqual(sent[1].params, [16]);
+        assert.equal(manager.queue.length, 1);
+        await manager.close();
     });
 });

--- a/test/testVacuumManager.js
+++ b/test/testVacuumManager.js
@@ -44,6 +44,7 @@ function createManager(sendMessage = async () => ({})) {
         setTimeout: (callback, delay) => setTimeout(callback, delay),
         clearTimeout: timeout => clearTimeout(timeout),
         getState: (id, callback) => callback(null, null),
+        /** @type {(id: string) => Promise<{ val?: unknown } | null>} */
         getStateAsync: async () => null,
         setStateAsync: async id => stateUpdates.push(id),
         setState: () => undefined,
@@ -409,6 +410,30 @@ describe('VacuumManager startCleaning room params', () => {
             { method: 'set_mop_mode', params: [300] },
         ]);
         assert.deepEqual(stateUpdates, ['control.fan_power', 'control.water_box_mode', 'control.mop_mode']);
+        await manager.close();
+    });
+
+    it('still starts cleaning when a parameter command fails', async () => {
+        const sent = [];
+        const { manager, adapter } = createManager(async (method, params) => {
+            sent.push({ method, params });
+            if (method === 'set_custom_mode') {
+                throw Object.assign(new Error('MIIO request timed out'), { code: 'MIIO_TIMEOUT' });
+            }
+            return { result: ['ok'] };
+        });
+        const warnings = [];
+        adapter.log.warn = /** @type {any} */ (
+            message => {
+                warnings.push(String(message));
+            }
+        );
+
+        const started = await manager.startCleaning(18, { channels: ['rooms.kitchen'], fanSpeed: 104 });
+
+        assert.equal(started, true);
+        assert.deepEqual(sent, [{ method: 'set_custom_mode', params: [104] }]);
+        assert.equal(warnings.some(message => message.includes('Could not apply cleaning parameters')), true);
         await manager.close();
     });
 

--- a/test/testVacuumMigration.js
+++ b/test/testVacuumMigration.js
@@ -45,6 +45,7 @@ describe('VacuumManager TypeScript runtime contract', () => {
         const VacuumManager = loadManager('../build/lib/vacuum');
 
         assert.deepEqual(Object.getOwnPropertyNames(VacuumManager.prototype).sort(), [
+            'applyCleaningParams',
             'asyncForEach',
             'checkFeaturesCarpet',
             'checkFeaturesRoomMapping',


### PR DESCRIPTION
## Summary

This PR carries the change from #1231 by @kosmix1980 onto the current `master` (after #1236) and adds the follow-up needed to pass the repository's guard tests. The original commit is kept with its authorship; a second commit contains the follow-up.

### From #1231 (kosmix1980)

- Room fan, water box mode/level and mop settings are read with `getStateAsync` and applied through miIO (`set_custom_mode`, `set_water_box_custom_mode`, `set_water_box_distance_off`, `set_mop_mode`) **before** the clean command is sent. The corresponding `control.*` states are updated with `ack: true`. Previously the settings were fire-and-forget `setStateChanged` calls that raced against the start command, so queued multi-room and repeat jobs often kept the robot default.
- A rejected native `app_segment_clean` repeat object no longer persists `segemntCleanRepeat` in `deviceInfo.unsupported`. The lockout is kept in memory for the current run only.

### Follow-up in this PR

- `test/testVacuumMigration.js`: add `applyCleaningParams` to the reviewed prototype contract (the guard test failed on the original branch).
- `test/testVacuumManager.js`: type the `getStateAsync` stub so `npm run check` passes.
- `startCleaning`: a failing fan/water/mop parameter command now logs a warning and the cleaning still starts. Without this, a single UDP timeout on `set_custom_mode` would have aborted the whole room cleaning, which was not possible before #1231.
- Regression test for the resilient start and changelog entries under `### **WORK IN PROGRESS**`.

## Tests

- `npm run lint` passes
- `npm run check` passes
- `npm run test:js`: 217 passing
- `npm run build` and `npm run test:package`: 81 passing

## Related

- Supersedes #1231 (same change plus the follow-up); the queue logic touched here is also where #1032 (`waitingposition` state for queued rooms) lives, but #1032 is not claimed as fixed by this PR.

Closes #1231
